### PR TITLE
fix: always add redirect to login navigation, don't go back

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -11,6 +11,11 @@ const routes = [
   {
     path: "/login",
     name: "Login",
+    beforeEnter: (to, from) => {
+      if (!to.query.redirect) {
+        return { path: to.path, query: { redirect: from.path } };
+      }
+    },
     component: () =>
       import(/* webpackChunkName: "login" */ "../views/Login.vue")
   },

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -85,7 +85,7 @@ export default {
           if (this.$route.query.redirect) {
             this.$router.push(this.$route.query.redirect);
           } else {
-            this.$router.back();
+            console.error("no redirect found");
           }
         } else {
           this.error = `User account not approved: ${status}`;


### PR DESCRIPTION
Previously, if navigating directly to `/login` on login the router would go back, but that was outside of the history of the app (could be a totally different website).  This enforces the redirect is always present.