### PR TITLE
feat: modal no longer closes if click outside of modal

### DIFF
--- a/src/views/snack/Forms.vue
+++ b/src/views/snack/Forms.vue
@@ -87,7 +87,7 @@
       data-cy="active-form-modal"
     >
       <div class="modal-background"></div>
-      <div class="modal-content is-family-secondary">
+      <div class="modal-card is-family-secondary">
         <header class="modal-card-head">
           <p class="modal-card-title" data-cy="active-form-title">
             {{ activeForm.title }}
@@ -237,7 +237,7 @@ export default {
 }
 
 @include mobile {
-  .modal-content {
+  .modal-card {
     max-height: 100vh;
   }
 


### PR DESCRIPTION
The modal no longer closes if you click outside of the modal.

Also the header now stays on screen and only the body scrolls. The close button is always visible now.