### PR TITLE
fix: use unique id for radio button

### DIFF
--- a/src/components/form/LikertScale.vue
+++ b/src/components/form/LikertScale.vue
@@ -31,7 +31,7 @@
                 <input
                   type="radio"
                   :name="`${uuid}-statements-${i}`"
-                  :id="`statements-${i}-${j}`"
+                  :id="`${uuid}-statements-${i}-${j}`"
                   :data-key="`statements-${i}`"
                   :value="option"
                   :checked="


### PR DESCRIPTION
Each radio button has a unique id now and we now use `data-key` for the key for the model.

Fixes this issue:
[screenshot](https://user-images.githubusercontent.com/5270855/130110189-2b59a663-09c3-4e07-ac83-d311a2d7ed7a.png)
