### PR TITLE
fix: cloneDeep when initializing the form

### DIFF
--- a/src/components/form/JSONForm.vue
+++ b/src/components/form/JSONForm.vue
@@ -70,7 +70,9 @@ export default {
   },
   emits: ["save", "submitted", "close"],
   setup(props, { emit }) {
-    const value = ref({ ...props.initValue });
+    const cloneDeep = (value) => JSON.parse(JSON.stringify(value));
+
+    const value = ref(cloneDeep(props.initValue));
     useSchemaForm(value);
 
     const schema = ref([...props.initSchema]);
@@ -91,8 +93,6 @@ export default {
       });
     };
     evalSchema(schema.value, yup);
-
-    const cloneDeep = (value) => JSON.parse(JSON.stringify(value));
 
     const saveDisabled = computed(
       () =>

--- a/tests/e2e/specs/form.spec.js
+++ b/tests/e2e/specs/form.spec.js
@@ -185,6 +185,35 @@ describe("Form functionality", () => {
         .find('[data-label="Rarely"]')
         .click();
 
+      // SAVE
+      cy.get('[data-cy="active-form-modal"]')
+        .find("button")
+        .contains("Save")
+        .should("be.enabled")
+        .click();
+
+      // CLOSE
+      cy.get('[data-cy="close-form"]').click();
+
+      // REOPEN
+      cy.contains('[data-cy="forms-panel-block"]', "My Form")
+        .find('[data-cy="launch-form-button"]')
+        .click();
+
+      // Change answer!
+      cy.get('[model="likert_scale_activities"]')
+        .find("tr")
+        .eq(1)
+        .find('[data-label="Rarely"]')
+        .click();
+
+      // SAVE
+      cy.get('[data-cy="active-form-modal"]')
+        .find("button")
+        .contains("Save")
+        .should("be.enabled")
+        .click();
+
       // Submit the form
       cy.get('[data-cy="active-form-modal"]')
         .find("button")
@@ -293,6 +322,12 @@ describe("Form functionality", () => {
         .find("tr")
         .eq(1)
         .find('[data-label="Never"] > input')
+        .should("not.be.checked");
+
+      cy.get('[model="likert_scale_activities"]')
+        .find("tr")
+        .eq(1)
+        .find('[data-label="Rarely"] > input')
         .should("be.checked");
 
       cy.get('[model="likert_scale_activities"]')


### PR DESCRIPTION
Save button now activates when reopening a form and editing answers to likert scale questions. 

closes #88 