### PR TITLE
feat: styling of zoomed map

### DIFF
--- a/src/components/dashboard/BGMap.vue
+++ b/src/components/dashboard/BGMap.vue
@@ -6,9 +6,6 @@
 import { ref, toRefs, computed } from "vue";
 
 import * as topology from "topojson-server";
-import * as tc from "topojson-client";
-import * as ts from "topojson-simplify";
-const topojson = { ...ts, ...tc };
 
 import { useVega } from "@/composables/useVega.js";
 import geo from "@/assets/geojson/ri.json";
@@ -33,20 +30,7 @@ export default {
         blocks: { type: "FeatureCollection", features: filtered },
       };
 
-      let topo = topology.topology(collection, 1e5);
-
-      // simplify/smooth out the geometry a bit
-      const sphericalArea = 1e-9;
-      topo = topojson.presimplify(topo, topojson.sphericalTriangleArea);
-      topo = topojson.simplify(topo, sphericalArea);
-      topo = topojson.filter(
-        topo,
-        topojson.filterAttachedWeight(
-          topo,
-          sphericalArea,
-          topojson.sphericalRingArea
-        )
-      );
+      let topo = topology.topology(collection, 1e9);
 
       return topo;
     });
@@ -109,7 +93,8 @@ export default {
             from: { data: "bg_outlines" },
             encode: {
               enter: {
-                strokeWidth: { value: 1 },
+                strokeWidth: { value: 6 },
+                strokeOpacity: { value: 0.6 },
               },
             },
             transform: [{ type: "geoshape", projection: "projection" }],


### PR DESCRIPTION
* Don't simplify the block group borders at all
* Make the border much thicker, but also somewhat opaque so landmarks underneath are still readable

![image](https://user-images.githubusercontent.com/24885580/134062492-d2de1b18-733c-48a2-994c-dc00c7e6d51a.png)

closes #102, closes #101 