### PR TITLE
Starter set of example queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ This web app uses the Cypress testing framework alongside a locally run Firestor
 In order for `firebase-admin` to have read/write access during testing, we need to include a private key.
 
 1. Navigate to the Firebase console to generate a private key (Settings > Service Accounts).
-1. Click **Generate New Private Key** and save the JSON file as `serviceAccount.json`
-1. Add that JSON file to the project root directory. This file is listed in the `.gitignore`. Do not share this private key.
+2. Click **Generate New Private Key** and save the JSON file as `serviceAccount.json`
+3. Add that JSON file to the project root directory. This file is listed in the `.gitignore`. Do not share this private key.
 
 ### Running the tests
 
@@ -248,3 +248,7 @@ Various actions are logged as a user interacts with the app:
 * `launch form`: the user launches a form on the forms page, `subAction` is the form id
 * `create NRA`: the user selects the create button on the neighborhood rapid assessment widget, `subAction` is the selected geoid
 * `launch NRA form`: the user launches a form on the NRA widget, `subAction` is the form id
+
+## Querying the Data
+
+See [`query_examples/`](query_examples) for more on how to get data out of firebase.

--- a/query_examples/README.md
+++ b/query_examples/README.md
@@ -1,0 +1,26 @@
+# Query Examples
+
+How do I get this data out of firebase anyway??
+
+## Some notes to get started
+
+1. To query the data from firebase, you must be added as a user on the project. Reach out
+   to a project admin to get added or request data.
+
+2. We have a quota on the number of data reads/writes we can do per day, so please query data then write to file so you can reuse that data for your analysis.
+
+3. Your queries are auditable :ghost:
+
+4. You'll need a key!
+
+  In order for `firebase-admin` to have read/write access during testing, we need to include a private key.
+
+  1. Navigate to the Firebase console to generate a private key (Settings > Service Accounts).
+  2. Click **Generate New Private Key** and save the JSON file as `serviceAccount.json`
+  3. Add that JSON file to the project root directory. This file is listed in the `.gitignore`. Do not share this private key.
+
+4. Don't commit data you save back to the repo, save it somewhere else please!
+
+5. These example scripts are meant to be just that, examples. Feel free to extend them and take inspiration from them or add to the collection!
+
+6. The firebase docs are thorough (though a little sprawling) [this is a good starting place](https://firebase.google.com/docs/firestore/query-data/get-data). Note - we are using firebase web version 8 when looking at their examples.

--- a/query_examples/activity_logs.js
+++ b/query_examples/activity_logs.js
@@ -1,0 +1,26 @@
+// env GOOGLE_APPLICATION_CREDENTIALS must contain the path to your firebase credentials
+// usage: `node activity_logs.js`
+// queries all of the activity logs for all users and saves them to a file in downloads
+// called `activity_logs.json`. The document ID is added to the data's `id` key.
+// adapted from https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query
+
+const admin = require("firebase-admin");
+const fs = require("fs");
+
+process.env.GOOGLE_APPLICATION_CREDENTIALS = "serviceAccount.json";
+
+const app = admin.initializeApp();
+const db = app.firestore();
+
+const FILE_PATH = "~/downloads/activity_logs.json";
+
+db.collectionGroup("activity_log")
+  .get()
+  .then((querySnapshot) => {
+    const results = [];
+    querySnapshot.forEach((doc) => {
+      results.push({ id: doc.id, ...doc.data() });
+    });
+
+    fs.writeFileSync(FILE_PATH, JSON.stringify(results));
+  });

--- a/query_examples/form_responses.js
+++ b/query_examples/form_responses.js
@@ -1,0 +1,26 @@
+// env GOOGLE_APPLICATION_CREDENTIALS must contain the path to your firebase credentials
+// usage: `node form_responses.js`
+// queries all of the form responses for all users and organizations and saves them to a file in downloads
+// called `form_responses.json`. The document ID is added to the data's `id` key.
+// adapted from https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query
+
+const admin = require("firebase-admin");
+const fs = require("fs");
+
+process.env.GOOGLE_APPLICATION_CREDENTIALS = "serviceAccount.json";
+
+const app = admin.initializeApp();
+const db = app.firestore();
+
+const FILE_PATH = "~/downloads/form_responses.json";
+
+db.collectionGroup("form_responses")
+  .get()
+  .then((querySnapshot) => {
+    const results = [];
+    querySnapshot.forEach((doc) => {
+      results.push({ id: doc.id, ...doc.data() });
+    });
+
+    fs.writeFileSync(FILE_PATH, JSON.stringify(results));
+  });

--- a/query_examples/user_form_response.js
+++ b/query_examples/user_form_response.js
@@ -1,0 +1,31 @@
+// env GOOGLE_APPLICATION_CREDENTIALS must contain the path to your firebase credentials
+// usage: `node user_form_response.js`
+// queries form responses for a scpecific user and form type and saves them to a file in downloads
+// called `form_response.json`. The document ID is added to the data's `id` key.
+// adapted from https://firebase.google.com/docs/firestore/query-data/queries
+
+const admin = require("firebase-admin");
+const fs = require("fs");
+
+process.env.GOOGLE_APPLICATION_CREDENTIALS = "serviceAccount.json";
+
+const app = admin.initializeApp();
+const db = app.firestore();
+
+const FILE_PATH = "~/downloads/form_response.json";
+const USER = "email@email.com"; // UPDATE THIS!
+const FORM_ID = "neighborhood_rapid_assessment";
+
+db.collection("user")
+  .doc(USER)
+  .collection("form_responses")
+  .where("form_id", "==", FORM_ID)
+  .get()
+  .then((querySnapshot) => {
+    const results = [];
+    querySnapshot.forEach((doc) => {
+      results.push({ id: doc.id, ...doc.data() });
+    });
+
+    fs.writeFileSync(FILE_PATH, JSON.stringify(results));
+  });


### PR DESCRIPTION
* Create a folder for example queries
* Link readme to that folder
* Have instructions in the readme there and sample scripts
* Each script contains a common use case/pattern and is meant to be a starter file, not meant to be the exact thing someone might need
* Can build up more over time as use cases arise