### PR TITLE
fix: tablet tooltips

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="">
+<html lang="" ontouchmove>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/components/dashboard/StatsTableContent.vue
+++ b/src/components/dashboard/StatsTableContent.vue
@@ -202,7 +202,6 @@ table tbody tr.header-row {
   text-align: center;
   padding: 5px 5px;
   border-radius: 3px;
-  cursor: pointer;
 
   /* Position the tooltip text - see examples below! */
   position: absolute;


### PR DESCRIPTION
Add `ontouchmove` to html, allows short taps to register as hover events and tapping elsewhere to clear it.

https://dev.webonomic.nl/fixing-the-iphone-css-hover-problem-on-ios