### PR TITLE
fix: add release date to dashboard forms

### DIFF
--- a/src/components/dashboard/AssessmentWidget.vue
+++ b/src/components/dashboard/AssessmentWidget.vue
@@ -96,6 +96,7 @@ import { useStore } from "vuex";
 
 import {
   sortByProperty,
+  today,
   GEOID_QUESTION_MODEL,
   MUNI_QUESTION_MODEL,
 } from "@/utils/utils.js";
@@ -156,7 +157,7 @@ export default {
     const createNewBGForm = (form_id) => {
       activeFormResponse.value = {
         form: store.state.forms[form_id],
-        release_date: new Date().toISOString().split("T")[0],
+        release_date: today(),
         status: "Not Started",
         response: {
           [GEOID_QUESTION_MODEL]: activeGeoid.value,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -29,7 +29,7 @@ export const sortByProperty = (property) => (a, b) => {
 };
 
 export const today = () => {
-  return new Date().toISOString().split("T")[0];
+  return new Date().toLocaleDateString("sv");
 };
 
 export const uniqueId = () => {

--- a/tests/e2e/specs/form-assignment.spec.js
+++ b/tests/e2e/specs/form-assignment.spec.js
@@ -11,7 +11,7 @@ const selectForm = (formTitle) => {
  * Sets the release date to today and the expire date to 3000-01-01
  */
 const setDatesAndSubmit = () => {
-  const today = new Date().toISOString().split("T")[0]; // Date to ISO string without time
+  const today = new Date().toLocaleDateString("sv");
   cy.get('[model="release_date"]').find("input").type(today);
   cy.get('[model="expire_date"]').find("input").type("3000-01-01");
 


### PR DESCRIPTION
Regular users only see forms in the forms page if the release date is less than or equal to today. Need to add in a release date to the rapid assessment and plan forms from the dashboard to have them appropriately show up.