### PR TITLE
fix: disabled text for safari

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -1,5 +1,4 @@
 // variables.scss automatically loaded by webpack
-@import "~bulma/sass/utilities/initial-variables";
 @import "bulma-responsive-tables";
 
 $box-radius: 2px;


### PR DESCRIPTION
- Makes the disabled fields easier to read on Safari and iOS

## Screenshots
### Before
[(Left is Safari, Right is Chrome)](https://user-images.githubusercontent.com/5270855/156812443-d8bd0392-45d3-4d37-88d7-8f03752e0e98.png)
[Mobile (iphone)](https://user-images.githubusercontent.com/5270855/156823716-5b248780-f19c-4cb2-93f0-676748024422.PNG)


### After
### Safari
<img width="827" alt="Screen Shot 2022-03-04 at 1 28 34 PM" src="https://user-images.githubusercontent.com/5270855/156820986-be13ed63-4c48-40d5-89f3-48e253f4b10f.png">

### Mobile (iphone)
![IMG_6496](https://user-images.githubusercontent.com/5270855/156823700-bc42acbd-e5d7-464b-b8f3-b997b1e1076b.PNG)

Closes #223 