### PR TITLE
fix: edge case, when a user doesn't have any forms

### DIFF
--- a/src/components/FormsPanel.vue
+++ b/src/components/FormsPanel.vue
@@ -193,7 +193,12 @@
         </li>
 
         <!-- Show ... between the first page and the page range -->
-        <li v-if="!(innerPageRange.includes(1) || innerPageRange.includes(2))">
+        <li
+          v-if="
+            !(innerPageRange.includes(1) || innerPageRange.includes(2)) &&
+            totalPages > 2
+          "
+        >
           <span class="pagination-ellipsis">&hellip;</span>
         </li>
 
@@ -215,7 +220,7 @@
             !(
               innerPageRange.includes(totalPages) ||
               innerPageRange.includes(totalPages - 1)
-            )
+            ) && totalPages > 2
           "
         >
           <span class="pagination-ellipsis">&hellip;</span>
@@ -319,8 +324,9 @@ const currentPage = ref(1);
 const maxFormResponsesPerPage = 15;
 
 const totalPages = computed(() => {
-  return Math.ceil(
-    filteredFormResponses.value.length / maxFormResponsesPerPage
+  return Math.max(
+    Math.ceil(filteredFormResponses.value.length / maxFormResponsesPerPage),
+    1
   );
 });
 


### PR DESCRIPTION
## Before
<img width="1345" alt="Screen Shot 2022-08-24 at 1 50 25 PM" src="https://user-images.githubusercontent.com/5270855/186489050-cfc54a61-a596-46ce-bbfb-d28000dc61a2.png">

## After
<img width="1332" alt="Screen Shot 2022-08-24 at 1 46 31 PM" src="https://user-images.githubusercontent.com/5270855/186489052-b75b9451-8c06-40dc-b63b-4627cb93d8bf.png">
