### PR TITLE
fix: admin emails - prefix admin variable with VITE

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-VUE_APP_ADMIN_EMAIL=maxwell_krieger@brown.edu
+VITE_APP_ADMIN_EMAIL=maxwell_krieger@brown.edu

--- a/src/views/admin/ReviewAccessRequests.vue
+++ b/src/views/admin/ReviewAccessRequests.vue
@@ -116,7 +116,7 @@ export default {
       const body = `<p>Hello ${
         user.name
       },</p><br><p>Your request to access PROVIDENT has been denied. If you believe this is an error, please reach out to <a href='mailto:${
-        import.meta.env.VUE_APP_ADMIN_EMAIL
+        import.meta.env.VITE_APP_ADMIN_EMAIL
       }'>the PROVIDENT admin</a>.</p>`;
 
       await fb.createEmail({

--- a/src/views/auth/Login.vue
+++ b/src/views/auth/Login.vue
@@ -109,7 +109,7 @@ export default {
           }
         } else if (status === undefined) {
           error.value = `User account was not set up properly. Please reach out to ${
-            import.meta.env.VUE_APP_ADMIN_EMAIL
+            import.meta.env.VITE_APP_ADMIN_EMAIL
           } with the email you used to register.`;
           await fb.logout();
         } else {

--- a/src/views/auth/Register.vue
+++ b/src/views/auth/Register.vue
@@ -264,14 +264,14 @@ export default {
           await fb.createEmail({
             subject: "PROVIDENT User Request",
             body: `<p>${form.name} (${form.email} from ${form.organization}) has requested access to PROVIDENT. <a href="${location.origin}/admin">View the request.</a></p>`,
-            to: [import.meta.env.VUE_APP_ADMIN_EMAIL],
+            to: [import.meta.env.VITE_APP_ADMIN_EMAIL],
           });
           await fb.createEmail({
             subject: "PROVIDENT Access Request",
             body: `<p>Hello ${
               form.name
             },</p><br><p>Your request to access PROVIDENT has been received. An administrator will review and respond within a week. If it has been a while and you haven't heard anything, please reach out to <a href='mailto:${
-              import.meta.env.VUE_APP_ADMIN_EMAIL
+              import.meta.env.VITE_APP_ADMIN_EMAIL
             }'>the PROVIDENT admin</a>.</p>`,
             to: [form.email],
           });


### PR DESCRIPTION
The ViteJS documentation says "To prevent accidentally leaking env variables to the client, only variables prefixed with `VITE_` are exposed to your Vite-processed code."

closes #251 