### PR TITLE
fix: Map eats scroll events on mobile

### DIFF
--- a/src/components/dashboard/Map.vue
+++ b/src/components/dashboard/Map.vue
@@ -238,10 +238,6 @@ export default {
                 events: "@block_groups:mousedown",
                 update: "clicked === datum ? null : datum",
               },
-              {
-                events: "@block_groups:touchstart",
-                update: "clicked === datum ? null : datum",
-              },
             ],
           },
           {


### PR DESCRIPTION
On mobile devices, the touchstart listener on the maps makes it impossible to scroll on mobile devices. This is a similar issue as seen in Signal: https://github.com/pph-collective/signal-app/pull/207