### PR TITLE
fix: email relay

### DIFF
--- a/email_service/index.js
+++ b/email_service/index.js
@@ -24,7 +24,7 @@ if (emulator) {
   process.env.FIRESTORE_EMULATOR_HOST = "localhost:8088";
 }
 
-let EMAIL_SMTP = "smtp://mail-relay.brown.edu:25";
+let EMAIL_SMTP = "smtp://regmail.brown.edu:25";
 if (test) {
   EMAIL_SMTP = undefined;
 }


### PR DESCRIPTION
from brad

> Any services that are sending emails are likely broken - It seems like ISG turned off [mail-relay.brown.edu](http://mail-relay.brown.edu/) without notifying us :confused: I had to go in and fix SOMA right now. If you previously gave me a send-as or from address you should be able to swap [mail-relay.brown.edu](http://mail-relay.brown.edu/) for [regmail.brown.edu](http://regmail.brown.edu/)