### PR TITLE
Feat forms mobile cards

### DIFF
--- a/src/components/ColumnFiltering.vue
+++ b/src/components/ColumnFiltering.vue
@@ -1,5 +1,6 @@
 <template>
   <input
+    class="input is-small"
     type="text"
     :value="columnFilterValue ?? ''"
     placeholder="Search..."
@@ -17,3 +18,7 @@ const props = defineProps<{
 
 const columnFilterValue = props.column.getFilterValue();
 </script>
+
+<style lang="scss" scoped>
+@import "../assets/styles/main.scss";
+</style>

--- a/src/components/FormsPanel.vue
+++ b/src/components/FormsPanel.vue
@@ -60,7 +60,7 @@
           <table class="table is-striped">
             <thead>
               <tr
-                v-for="headerGroup in table.getHeaderGroups()"
+                v-for="headerGroup in table.getHeaderGroups().slice(1)"
                 :key="headerGroup.id"
               >
                 <th
@@ -68,6 +68,7 @@
                   :key="header.id"
                   :colSpan="header.colSpan"
                   :class="header.column.getCanSort() ? 'is-clickable' : ''"
+                  style="min-width: 100px"
                 >
                   <div
                     @click="header.column.getToggleSortingHandler()?.($event)"
@@ -86,6 +87,19 @@
                         : ""
                     }}
                   </div>
+                </th>
+              </tr>
+              <tr
+                v-for="headerGroup in table.getHeaderGroups().slice(1)"
+                :key="`${headerGroup.id}-column-filtering`"
+              >
+                <th
+                  v-for="header in headerGroup.headers"
+                  :key="`${header.id}-column-filtering`"
+                  :colSpan="header.colSpan"
+                  :class="header.column.getCanSort() ? 'is-clickable' : ''"
+                  style="min-width: 100px"
+                >
                   <div v-if="header.column.getCanFilter()">
                     <ColumnFiltering :column="header.column" :table="table" />
                   </div>
@@ -203,6 +217,7 @@ import FormModal from "./form/Modal.vue";
 
 const props = withDefaults(
   defineProps<{
+    admin: boolean;
     filterOptions: object;
     filterFunctions: object;
     formResponses: object[];
@@ -210,6 +225,7 @@ const props = withDefaults(
     readOnly: boolean;
   }>(),
   {
+    admin: false,
     filterOptions: () => ({}),
     filterFunctions: () => ({}),
     formResponses: () => [],
@@ -283,11 +299,13 @@ const columns = [
         cell: (info) => info.getValue(),
         header: () => "Block Group",
       }),
-      columnHelper.accessor("organization", {
-        id: "organization",
-        cell: (info) => info.getValue(),
-        header: () => "Organization",
-      }),
+      props.admin
+        ? columnHelper.accessor("organization", {
+            id: "organization",
+            cell: (info) => info.getValue(),
+            header: () => "Organization",
+          })
+        : null,
       columnHelper.accessor("user_submitted", {
         id: "user_submitted",
         cell: (info) => info.getValue(),
@@ -311,7 +329,7 @@ const columns = [
           }),
         header: () => "",
       }),
-    ],
+    ].filter((el) => el !== null),
   }),
 ];
 
@@ -368,7 +386,6 @@ const table = useVueTable({
   getPaginationRowModel: getPaginationRowModel(),
   getSortedRowModel: getSortedRowModel(),
 });
-
 
 const launchForm = (formResponse: { _id?: any }, readOnly: boolean) => {
   activeFormReadOnly.value = readOnly;

--- a/src/views/admin/ReviewForms.vue
+++ b/src/views/admin/ReviewForms.vue
@@ -3,6 +3,7 @@
 
   <FormsPanel
     title="Review Forms"
+    :admin="true"
     :filter-options="filterOptions"
     :filter-functions="filterFunctions"
     :form-responses="formResponses"


### PR DESCRIPTION
Provident Forms Page Swaps to card view on mobile!

A few notes though:

 - ~~There's some "blank" buttons that are weird and I dont fully understand why they're there or how to get rid of them. @eldu said she'd take a look?~~ Thanks Ellen!!
 - ~~The Mobile Filtering card appears at some narrow screen widths, before the table switches to cards. this is because, unintuitively, the Bulma Table `has-mobile-cards` and `is-desktop-hidden` have different breakpoints... The documentation on this is lacking unfortunately...~~ I looked up the Bulma CSS mobile breakpoint and just explicitly set the value. It's not pretty, but it works!

### Example (With filtering)

![provident-mobile-form](https://github.com/pph-collective/provident-app/assets/35873035/c68dd8cf-7030-4966-8702-e60870c30ffd)


