### PR TITLE
fix: modal pop up

### DIFF
--- a/src/components/dashboard/Map.vue
+++ b/src/components/dashboard/Map.vue
@@ -238,6 +238,10 @@ export default {
                 events: "@block_groups:mousedown",
                 update: "clicked === datum ? null : datum",
               },
+              {
+                events: "@block_groups:touchend",
+                update: "clicked === datum ? null : datum",
+              },
             ],
           },
           {


### PR DESCRIPTION
So it turns out the click event was getting swallowed by the map and erasing the geoid.

This PR, almost reverses https://github.com/pph-collective/provident-app/pull/282

However, instead of `touchstart` we now do `touchend` and somehow the scrolling is still fine ! 