### PR TITLE
feat: make filter header bar all clickable

### DIFF
--- a/src/components/FormsPanel.vue
+++ b/src/components/FormsPanel.vue
@@ -4,17 +4,20 @@
       <h1 class="title">Forms</h1>
       <!-- Expandable Filters Card -->
       <div class="card my-2">
-        <header class="card-header">
+        <header
+          class="card-header"
+          aria-label="more options"
+          style="cursor: pointer"
+          role="button"
+          :aria-pressed="displayFilters"
+          @click="() => (displayFilters = !displayFilters)"
+        >
           <div class="card-header-title">Filter & Sort</div>
-          <button
-            class="card-header-icon"
-            aria-label="more options"
-            @click="() => (displayFilters = !displayFilters)"
-          >
+          <div class="card-header-icon">
             <span class="icon">
               <i class="fas fa-angle-down" aria-hidden="true"></i>
             </span>
-          </button>
+          </div>
         </header>
         <div v-if="displayFilters" class="card-content filter-wrapper">
           <template


### PR DESCRIPTION
Fixes an issue where the entire filter header bar should be clickable but wasn't.


### Demo

![form filter expand demo](https://github.com/pph-collective/provident-app/assets/35873035/8d5e7f7c-2201-4f2e-914f-df3e37a13801)
