### PR TITLE
fix: mapbox token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# https://console.mapbox.com/account/access-tokens
+VITE_MAPBOX_API_KEY=

--- a/README.md
+++ b/README.md
@@ -27,6 +27,29 @@ yarn build
 yarn lint
 ```
 
+## API Key Setup
+
+### Setting up the Environment Variable
+
+Copy the `.env.example` file to create your own environment file:
+```bash
+  cp .env.example .env.local
+```
+
+>[!IMPORTANT]
+> Use `.env.local` (not `.env`) - this file is gitignored and won't be committed
+> Environment variables in Vite must be prefixed with `VITE_` to be accessible in the browser
+> Never commit your actual API keys to version control
+
+### MapBox
+
+This project uses MapBox for map rendering. To get the map working properly, you'll need to set up an API key.
+
+Open `.env.local` and add your actual API key:
+```
+  VITE_MAPBOX_API_KEY=your_actual_api_key_here
+```
+
 ### Setup Firebase Admin
 
 > [!NOTE]
@@ -46,3 +69,4 @@ The `firestore.rules` file (in the repo) was used to test edits to the firestore
 
 > [!NOTE]  
 > Activity logging is to be migrated over to using only Google Analytics [#338](https://github.com/pph-collective/provident-app/issues/338)
+

--- a/src/components/dashboard/BGMap.vue
+++ b/src/components/dashboard/BGMap.vue
@@ -13,6 +13,8 @@ import geo from "@/assets/geojson/ri.json";
 
 import { poriRed } from "@/utils/utils";
 
+const MAPBOX_API_KEY = import.meta.env.VITE_MAPBOX_API_KEY;
+
 const props = defineProps({
   blockGroup: {
     type: String,
@@ -69,8 +71,7 @@ const spec = computed(() => {
       {
         // Access token is restricted to certain domains in the mapbox settings
         name: "mapboxToken",
-        value:
-          "?access_token=pk.eyJ1IjoiY2N2LWJvdCIsImEiOiJja3ZsY2JzMHY2ZGRiMm9xMTQ0eW1nZTJsIn0.uydOaXlX1uQfxPrKfucB2A",
+        value: `?access_token=${MAPBOX_API_KEY}`,
       },
       { name: "basePoint", update: "invert('projection',[0,0])" },
       { name: "maxPoint", update: "invert('projection', [width, height])" },

--- a/src/components/dashboard/MainMap.vue
+++ b/src/components/dashboard/MainMap.vue
@@ -16,6 +16,8 @@ import zipcodesGeo from "@/assets/geojson/ri_zipcodes.json";
 
 import { sortByProperty, priorityToColor } from "@/utils/utils.js";
 
+const MAPBOX_API_KEY = import.meta.env.VITE_MAPBOX_API_KEY;
+
 const props = defineProps({
   dataset: {
     type: Array,
@@ -154,8 +156,7 @@ const spec = computed(() => {
       {
         // Access token is restricted to certain domains in the mapbox settings
         name: "mapboxToken",
-        value:
-          "?access_token=pk.eyJ1IjoiY2N2LWJvdCIsImEiOiJja3ZsY2JzMHY2ZGRiMm9xMTQ0eW1nZTJsIn0.uydOaXlX1uQfxPrKfucB2A",
+        value: `?access_token=${MAPBOX_API_KEY}`,
       },
       { name: "basePoint", update: "invert('projection',[0,0])" },
       { name: "maxPoint", update: "invert('projection', [width, height])" },


### PR DESCRIPTION
Previous, the mapbox token was restricted to certain urls on the mapbox site. In this PR I created a new token and am now just hiding it in env vars.